### PR TITLE
fix wrong method names for init and uninit

### DIFF
--- a/index.vue
+++ b/index.vue
@@ -63,10 +63,10 @@ export default {
   watch: {
     swicher(val) {
       if (val && !this._ps_inited) {
-        this.init()
+        this.__init()
       }
       if (!val && this._ps_inited) {
-        this.uninit()
+        this.__uninit()
       }
     },
 


### PR DESCRIPTION
In watch swicher function there were a mistake with the names of init and uninit function (missing the __ prefix)