### PR TITLE
Fix: ps.update was never called

### DIFF
--- a/index.vue
+++ b/index.vue
@@ -30,7 +30,7 @@ export default {
     },
     methods: {
         update() {
-            if (!this.ps) {
+            if (this.ps) {
                 this.ps.update();
             }
         },


### PR DESCRIPTION
My app needs to call ps.update() when its data changes and on resize, but without this fix, it is impossible to call through vue-perfect-scrollbar's ref.