### PR TITLE
Declare a module for non typescript libs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+// Declare a module for non typescript libs
+declare module 'vue-perfect-scrollbar';


### PR DESCRIPTION
This is a fix for the Typescript error "Could not find a declaration file for module 'vue-perfect-scrollbar'" whenever lang=ts is used in a Vue component